### PR TITLE
Remove horizontal padding from word search highlight

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -275,7 +275,7 @@ body {
 
 .highlight {
   background-color: #fef08a;
-  padding: 0.125rem 0.25rem;
+  padding: 0.125rem 0;
   border-radius: 2px;
 }
 


### PR DESCRIPTION
Remove horizontal padding on search highlights in text

Before:
<img width="649" height="147" alt="image" src="https://github.com/user-attachments/assets/59de43fc-2c8b-4d47-8818-866dfc0ed857" />


After:
<img width="658" height="134" alt="image" src="https://github.com/user-attachments/assets/97a35434-988b-4f9f-8fbb-b22a9ec9a9bd" />
